### PR TITLE
Filtrer les conseils vides avant de soumettre l'alerte dans AddPage

### DIFF
--- a/src/app/pages/add/add.page.ts
+++ b/src/app/pages/add/add.page.ts
@@ -240,14 +240,18 @@ export class AddPage implements OnInit {
 
     try {
       const imageUrls = this.selectedImages.map((img) => img.preview);
+      const formValue = this.alertForm.value;
+      const filteredTips = formValue.tips.filter((tip: string) => tip && tip.trim() !== '');
+
       const alertData = {
-        ...this.alertForm.value,
+        ...formValue,
+        tips: filteredTips,
         images: imageUrls,
         createdAt: new Date(),
         targetInstitutionId:
-          this.alertForm.value.target === 'all'
+          formValue.target === 'all'
             ? null
-            : this.alertForm.value.target,
+            : formValue.target,
       };
       await this.publicationService.addAlert(alertData as WeatherBulletin);
       await this.presentToast('Alerte publiée avec succès !', 'success');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents saving empty or whitespace-only tips during alert submission.
  * Ensures the selected target and corresponding institution are consistently applied when creating an alert.

* **Refactor**
  * Streamlined form handling by reading form values once for improved reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->